### PR TITLE
Fix for breaking change in localstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.0'
 
 services:
   localstack-profile: #this is the name of the service.  Note: it is ALSO the name of a host created by Docker compose
-    image: localstack/localstack:latest
+    image: localstack/localstack:0.12.11
     ports:
       - '4566:4566'
       - '${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}'

--- a/src/profile-lambda-csharp/appsettings.json
+++ b/src/profile-lambda-csharp/appsettings.json
@@ -8,7 +8,7 @@
       "RegionName": "eu-central-1"
     },
     "Config": {
-      "LocalStackHost": "localhost",
+      "LocalStackHost": "localstack-profile",
       "UseSsl": false,
       "UseLegacyPorts": false,
       "EdgePort": 4566

--- a/src/profile-lambda-csharp/client-test.sh
+++ b/src/profile-lambda-csharp/client-test.sh
@@ -21,10 +21,18 @@ export RESTAPI=$(awslocal apigateway get-rest-apis | ./json "items.0.id")
 echo testing POST...
 curl -X POST "http://localhost:4566/restapis/${RESTAPI}/local/_user_request_/profile" -H 'Content-Type: application/json' --data '@test.data'
 echo
-awslocal s3api list-objects --bucket profile-pictures | ./json "Contents.Key" grep -q 'my-profile2.pic.jpg' && echo 'S3 WAS LOADED SUCCESSFULLY'
-awslocal dynamodb scan --table-name Profiles | ./json "Items.0.Email.S" grep -q 'kulubettin@gmail.com' && echo 'DYNAMODB WAS LOADED SUCCESSFULLY'
-
+if (awslocal s3api list-objects --bucket profile-pictures | ./json "Contents.0.Key" | grep -q 'my-profile2.pic.jpg';) then
+    echo "S3 WAS LOADED SUCCESSFULLY BY POST";
+else
+    echo "S3 WAS NOT LOADED BY POST!!";
+fi    
+if (awslocal dynamodb scan --table-name Profiles | ./json "Items.0.Email.S" | grep -q 'kulubettin@gmail.com';) then
+    echo 'DYNAMODB WAS LOADED SUCCESSFULLY BY POST';
+else 
+    echo 'DYNAMODB WAS NOT LOADED BY POST!!';
+fi
 echo resetting the aws environment
+echo
 awslocal s3 rb s3://profile-pictures  --force > /dev/null # delete bucket if it exists 
 awslocal s3api create-bucket --bucket profile-pictures --region eu-central-1
 awslocal dynamodb delete-table --table-name Profiles > /dev/null # delete table if it exists
@@ -33,8 +41,15 @@ awslocal dynamodb create-table --table-name Profiles --attribute-definitions Att
 echo testing aws-cli invoke
 awslocal lambda invoke --cli-binary-format raw-in-base64-out --function-name profile-local-hello --payload "$(< testEscaped.data)" response.json --log-type Tail | ./json "LogResult" | base64 --decode
 echo
-awslocal s3api list-objects --bucket profile-pictures | ./json "Contents.Key" grep -q 'my-profile2.pic.jpg' && echo 'S3 WAS LOADED SUCCESSFULLY'
-awslocal dynamodb scan --table-name Profiles | ./json "Items.0.Email.S" grep -q 'kulubettin@gmail.com' && echo 'DYNAMODB WAS LOADED SUCCESSFULLY'
-
+if (awslocal s3api list-objects --bucket profile-pictures | ./json "Contents.0.Key" | grep -q 'my-profile2.pic.jpg';) then
+    echo "S3 WAS LOADED SUCCESSFULLY BY CLI";
+else
+    echo "S3 WAS NOT LOADED BY CLI!!";
+fi    
+if (awslocal dynamodb scan --table-name Profiles | ./json "Items.0.Email.S" | grep -q 'kulubettin@gmail.com';) then
+    echo 'DYNAMODB WAS LOADED SUCCESSFULLY BY CLI';
+else 
+    echo 'DYNAMODB WAS NOT LOADED BY CLI!!';
+fi
 
 

--- a/src/profile-lambda-csharp/serverless.yml
+++ b/src/profile-lambda-csharp/serverless.yml
@@ -32,7 +32,8 @@ functions:
     package:
       artifact: artifact/profile-lambda-csharp.zip
     environment:
-      LocalStack:Config:LocalStackHost: localstack-profile # matches service name from docker-compose.yml
+      # Config is set through appsettings.json, so the next line is not needed
+      # LocalStack:Config:LocalStackHost: localstack-profile # matches service name from docker-compose.yml
     events:
       - http:
           path: profile # This is the route used by the post 


### PR DESCRIPTION
Localstack 0.12.12 broke docker-compose, so the docker image is now fixed to 0.12.11.  Also, setting the lambda environment variables in serverless.yml for Config:LocalStackHost did not work in all environments, so that was eliminated and replaced with appsettings.json.

In addition, the grep test in client-test.sh was not working correctly, so that has been fixed.