### PR TITLE
chore: bump LocalStack.Aspire.Hosting version to 9.5.3 and update dep…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
         <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.5.2"/>
         <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.5.2"/>
         <PackageVersion Include="Aspire.Hosting.AWS" Version="9.3.0"/>
-        <PackageVersion Include="LocalStack.Aspire.Hosting" Version="9.5.2"/>
+        <PackageVersion Include="LocalStack.Aspire.Hosting" Version="9.5.3"/>
         <!-- LocalStack packages  -->
         <PackageVersion Include="LocalStack.Client" Version="2.0.0"/>
         <PackageVersion Include="LocalStack.Client.Extensions" Version="2.0.0"/>
@@ -51,7 +51,7 @@
         <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271"/>
         <!-- Logging packages -->
         <PackageVersion Include="Serilog" Version="4.3.0"/>
-        <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+        <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0"/>
         <PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0"/>
         <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0"/>
         <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0"/>


### PR DESCRIPTION
…endencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update central package version of `LocalStack.Aspire.Hosting` from `9.5.2` to `9.5.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 802fd821fafc0d3f276059cc65d23ced160a1a68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->